### PR TITLE
Fix: 반응형 루트 레이아웃과 페이지 레이아웃 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "json-server": "0.17.4",
     "postcss": "^8.4.44",
     "tailwindcss": "^3.4.10",
+    "terser": "^5.33.0",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1",

--- a/src/components/CommonHeader.tsx
+++ b/src/components/CommonHeader.tsx
@@ -1,11 +1,12 @@
-import { useNavigate } from "react-router-dom";
 import IconLeft from "icons/arrow-left.svg";
 import { useAtomValue } from "jotai";
 import { myPageHeaderProps } from "@/stores/mypage";
+import useCommon from "@/hooks/useCommon";
 
 interface CommonHeaderBaseProps {
   title: string;
   onBack?: () => void;
+  backRoute: string;
 }
 
 interface CommonHeaderWithConfirm extends CommonHeaderBaseProps {
@@ -23,15 +24,15 @@ interface CommonHeaderWithoutConfirm extends CommonHeaderBaseProps {
 export type CommonHeaderProps = CommonHeaderWithConfirm | CommonHeaderWithoutConfirm;
 
 const CommonHeader = () => {
-  const navigate = useNavigate();
-  const { title, onBack, hasConfirm, confirmText, onConfirm } = useAtomValue(myPageHeaderProps);
+  const { goBack } = useCommon();
+  const { title, onBack, backRoute, hasConfirm, confirmText, onConfirm } = useAtomValue(myPageHeaderProps);
 
   return (
     <header className="relative flex items-center justify-between w-full h-16 px-2">
       {/* 헤더 좌측 버튼 */}
       <button
         onClick={() => {
-          navigate(-1);
+          goBack(backRoute);
           if (onBack) onBack();
         }}
         className="flex items-center h-full px-4 py-0 bg-transparent"
@@ -40,9 +41,7 @@ const CommonHeader = () => {
       </button>
 
       {/* 헤더 중앙 제목 */}
-      <h1 className="absolute text-xl font-bold -translate-x-1/2 -translate-y-1/2 top-1/2 left-1/2">
-        {title}
-      </h1>
+      <h1 className="absolute text-xl font-bold -translate-x-1/2 -translate-y-1/2 top-1/2 left-1/2">{title}</h1>
 
       {/* 헤더 우측 버튼 */}
       {hasConfirm && (

--- a/src/components/layout/FooterNavBar.tsx
+++ b/src/components/layout/FooterNavBar.tsx
@@ -1,16 +1,23 @@
 import { footerMenus } from "@/components/layout/constants/menus";
 import FooterMenu from "./components/FooterMenu";
+import { useLocation } from "react-router-dom";
 
 const FooterNavBar = () => {
-  return (
-    <footer
-      className={`tablet:hidden z-50 fixed bottom-0 w-full bg-white h-[72px] grid grid-cols-5 border-t shrink-0 border-custom-gray-light`}
-    >
-      {footerMenus.map(({ name, to, iconComponent }, idx) => (
-        <FooterMenu key={idx} to={to} iconComponent={iconComponent} name={name} />
-      ))}
-    </footer>
-  );
+  const { pathname } = useLocation();
+
+  const validPaths = ["/", "/community", "/product", "/chatting", "/mypage", "/search"];
+
+  if (validPaths.includes(pathname)) {
+    return (
+      <footer
+        className={`tablet:hidden z-50 fixed bottom-0 w-full bg-white h-[72px] grid grid-cols-5 border-t shrink-0 border-custom-gray-light`}
+      >
+        {footerMenus.map(({ name, to, iconComponent }, idx) => (
+          <FooterMenu key={idx} to={to} iconComponent={iconComponent} name={name} />
+        ))}
+      </footer>
+    );
+  } else return null;
 };
 
 export default FooterNavBar;

--- a/src/components/layout/components/HeaderRight.tsx
+++ b/src/components/layout/components/HeaderRight.tsx
@@ -7,7 +7,7 @@ const HeaderRight = () => {
     <div className="items-center hidden h-full gap-4 tablet:flex">
       <HeaderUserInfo />
 
-      <div className="hidden tablet:block desktop:hidden">
+      <div className="hidden h-full tablet:block desktop:hidden">
         <MenuDropDown options={headerDropdownMenus} />
       </div>
     </div>

--- a/src/components/layout/components/HeaderUserInfo.tsx
+++ b/src/components/layout/components/HeaderUserInfo.tsx
@@ -10,8 +10,8 @@ const HeaderUserInfo = () => {
   return (
     <Link
       to={"/mypage"}
-      className={`items-center justify-center hidden w-6 h-6 bg-custom-gray-light bg-center bg-no-repeat bg-cover rounded-full border-custom-gray-dark aspect-square tablet:flex ${
-        !userInfo?.image && "border"
+      className={`items-center justify-center hidden w-7 h-7 bg-custom-gray-light bg-center bg-no-repeat bg-cover rounded-full border-custom-gray-dark aspect-square tablet:flex ${
+        !userInfo?.image && "border-none"
       }`}
       style={bGAvatarStyle}
     >

--- a/src/components/layout/components/MenuDropDown.tsx
+++ b/src/components/layout/components/MenuDropDown.tsx
@@ -31,7 +31,7 @@ const MenuDropDown = ({ options }: MenuDropDownProps) => {
   return (
     <div className="flex flex-col h-full gap-2" ref={dropDownRef}>
       <button onClick={() => setIsOpen((prev) => !prev)} className="h-full bg-white">
-        {isOpen ? <IconClose className="w-6 h-6 text-custom-gray-dark" /> : <IconMenu className="w-6 h-6" />}
+        {isOpen ? <IconClose className="w-7 h-7 text-custom-gray-dark" /> : <IconMenu className="w-7 h-7" />}
       </button>
 
       <div

--- a/src/components/layout/constants/menus.tsx
+++ b/src/components/layout/constants/menus.tsx
@@ -3,6 +3,7 @@ import IconProduct from "@/assets/icons/icon-product.svg";
 import IconHome from "@/assets/icons/icon-home.svg";
 import IconChat from "@/assets/icons/icon-chat.svg";
 import IconAccount from "@/assets/icons/icon-account.svg";
+import { removeLocalStorage } from "@/utils/storageUtils";
 
 interface HeaderMenusTypes {
   name: string;
@@ -28,5 +29,12 @@ export const headerMainMenus: { name: string; to: string }[] = [
 export const headerDropdownMenus: HeaderMenusTypes[] = [
   ...headerMainMenus,
   { name: "마이페이지", to: "/mypage" },
-  { name: "로그아웃", onClick: () => console.log("로그아웃"), iconRemove: true },
+  {
+    name: "로그아웃",
+    onClick: () => {
+      removeLocalStorage();
+      window.location.href = "auth/signin";
+    },
+    iconRemove: true,
+  },
 ];

--- a/src/components/pageLayout/PageLayout.tsx
+++ b/src/components/pageLayout/PageLayout.tsx
@@ -1,10 +1,10 @@
 import { Outlet } from "react-router-dom";
-import CommonHeader from "@/components/CommonHeader";
+import PageLayoutHeader from "@/components/pageLayout/PageLayoutHeader";
 
 const PageLayout = () => {
   return (
     <div className="flex flex-col w-full h-full">
-      <CommonHeader />
+      <PageLayoutHeader />
       <main className="flex justify-center w-full h-full overflow-hidden overflow-y-scroll scrollbar-hide mobile:px-4 desktop:px-10 max-w-7xl">
         <Outlet />
       </main>

--- a/src/components/pageLayout/PageLayoutHeader.tsx
+++ b/src/components/pageLayout/PageLayoutHeader.tsx
@@ -1,31 +1,11 @@
 import IconLeft from "icons/arrow-left.svg";
 import { useAtomValue } from "jotai";
-import { myPageHeaderProps } from "@/stores/mypage";
+import { pageLayoutHeaderProps } from "@/stores/mypage";
 import useCommon from "@/hooks/useCommon";
 
-interface CommonHeaderBaseProps {
-  title: string;
-  onBack?: () => void;
-  backRoute: string;
-}
-
-interface CommonHeaderWithConfirm extends CommonHeaderBaseProps {
-  hasConfirm: true; // hasConfirm이 true일 때
-  confirmText: string; // confirmText는 필수
-  onConfirm?: () => void;
-}
-
-interface CommonHeaderWithoutConfirm extends CommonHeaderBaseProps {
-  hasConfirm: false; // hasConfirm이 false일 때
-  confirmText?: null; // confirmText는 선택
-  onConfirm?: null;
-}
-
-export type CommonHeaderProps = CommonHeaderWithConfirm | CommonHeaderWithoutConfirm;
-
-const CommonHeader = () => {
+const PageLayoutHeader = () => {
   const { goBack } = useCommon();
-  const { title, onBack, backRoute, hasConfirm, confirmText, onConfirm } = useAtomValue(myPageHeaderProps);
+  const { title, onBack, backRoute, hasConfirm, confirmText, onConfirm } = useAtomValue(pageLayoutHeaderProps);
 
   return (
     <header className="relative flex items-center justify-between w-full h-16 px-2">
@@ -58,4 +38,4 @@ const CommonHeader = () => {
   );
 };
 
-export default CommonHeader;
+export default PageLayoutHeader;

--- a/src/hooks/useCommon.ts
+++ b/src/hooks/useCommon.ts
@@ -5,8 +5,12 @@ const useCommon = () => {
   const navigate = useNavigate();
   const [previewAvatar, setPreviewAvatar] = useState("");
 
-  const goBack = () => {
-    navigate(-1);
+  const goBack = (fallbackRoute?: string) => {
+    const hasBrowserStacks = window.history.length > 1;
+
+    if (hasBrowserStacks) navigate(-1);
+    else if (fallbackRoute) navigate(fallbackRoute);
+    else navigate("/");
   };
 
   const extractUrlFromImageFile = (file: File) => {

--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,9 @@
   line-height: 1.5;
   font-weight: 400;
   font-size: 16px;
+  @apply text-base;
+  @apply tablet:text-lg;
+  /* @apply desktop:text-xl; */
 
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);

--- a/src/index.css
+++ b/src/index.css
@@ -7,9 +7,6 @@
   line-height: 1.5;
   font-weight: 400;
   font-size: 16px;
-  @apply text-base;
-  @apply tablet:text-lg;
-  /* @apply desktop:text-xl; */
 
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);

--- a/src/pages/NotfoundPage.jsx
+++ b/src/pages/NotfoundPage.jsx
@@ -10,13 +10,13 @@ const NotFoundPage = () => {
   };
 
   return (
-    <div className="flex flex-col items-center justify-center h-screen bg-custom-green px-4 text-custom-black">
-      <div className="flex items-center justify-center gap-x-4 w-11/12">
+    <div className="flex flex-col items-center justify-center h-screen px-4 bg-custom-green text-custom-black">
+      <div className="flex items-center justify-center w-11/12 gap-x-4">
         <div className="w-1/3 max-w-[180px]">
-          <LogoImg alt="Fresh 2 You" className="rounded-lg h-auto" />
+          <LogoImg alt="Fresh 2 You" className="h-auto rounded-lg" />
         </div>
         <div className="flex flex-col items-start">
-          <h1 className=" text-white text-custom-h font-semibold">404</h1>
+          <h1 className="font-semibold text-white  text-custom-h">404</h1>
           <p className="font-medium text-custom-p">페이지를 찾을 수 없습니다.</p>
         </div>
       </div>

--- a/src/pages/mypage/components/PageLayout.tsx
+++ b/src/pages/mypage/components/PageLayout.tsx
@@ -1,15 +1,15 @@
 import { Outlet } from "react-router-dom";
 import CommonHeader from "@/components/CommonHeader";
 
-const MyPageLayout = () => {
+const PageLayout = () => {
   return (
     <div className="flex flex-col w-full h-full">
       <CommonHeader />
-      <main className="w-full h-full overflow-hidden overflow-y-scroll scrollbar-hide">
+      <main className="flex justify-center w-full h-full overflow-hidden overflow-y-scroll scrollbar-hide mobile:px-4 desktop:px-10 max-w-7xl">
         <Outlet />
       </main>
     </div>
   );
 };
 
-export default MyPageLayout;
+export default PageLayout;

--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -1,0 +1,19 @@
+import { removeLocalStorage } from "@/utils/storageUtils";
+import { Navigate, Outlet } from "react-router-dom";
+
+const ProtectedRoute = () => {
+  const accessToken = localStorage.getItem("accessToken");
+  const tokenExpirationTime = localStorage.getItem("accessExpiredAt");
+  const currentTime = new Date();
+
+  if (!accessToken || !tokenExpirationTime || new Date(tokenExpirationTime) < currentTime) {
+    // 토큰이 없거나 만료됐으면 로그인 페이지로 이동
+    removeLocalStorage();
+
+    return <Navigate to="/auth/signin" replace />;
+  }
+  // 토큰이 있거나 아직 유효하다면 자식 라우트를 렌더링
+  return <Outlet />;
+};
+
+export default ProtectedRoute;

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -16,7 +16,7 @@ import ProductPurchasePage from "../pages/product/ProductPurchasePage";
 import PaymentCompletePage from "@/pages/product/PaymentCompletePage";
 import ChatListPage from "@/pages/chat/ChatListPage";
 import ChatPage from "@/pages/chat/ChatPage";
-import PageLayout from "@/pages/mypage/components/PageLayout";
+import PageLayout from "@/components/pageLayout/PageLayout";
 import MyPage from "@/pages/mypage/mypage/MyPage";
 import PointPage from "@/pages/mypage/charge/PointPage";
 import VerifySellerPage from "@/pages/mypage/verifySeller/VerifySellerPage";

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -24,6 +24,9 @@ import LikeListPage from "@/pages/mypage/likes/LikeListPage";
 import ChangePasswordPage from "@/pages/mypage/password/ChangePasswordPage";
 import ChangeProfilePage from "@/pages/mypage/profile/ChangeProfilePage";
 import DeliveriesPage from "@/pages/mypage/deliveries/DeliveriesPage";
+import CommunityPage from "@/pages/community/CommunityPage";
+import CommunityPostPage from "@/pages/community/CommunityPostPage";
+import ProtectedRoute from "@/routes/ProtectedRoute";
 
 /* TODO: 라우트별 element를 임시로 채운 부분 해당 컴포넌트로 수정 */
 /* TODO: Route들을 묶어서 파일 관리로 수정 예정 */
@@ -49,71 +52,68 @@ const Router = (): JSX.Element => {
       />
 
       {/* TODO: 여기 아래로는 ProtectedRoute 컴포넌트로 감쌀 예정 */}
-      {/* TODO: 홈/검색 외에도 루트 레이아웃으로 감쌀 예정 */}
-      <Route element={<RootLayout />}>
-        {/* 홈페이지 & 검색페이지 */}
-        <Route path="/" element={<HomePage />} />
-        <Route path="/search" element={<SearchPage />} />
-        <Route path="/mypage" element={<MyPage />} />
-      </Route>
+      <Route element={<ProtectedRoute />}>
+        {/* TODO: 홈/검색 외에도 루트 레이아웃으로 감쌀 예정 */}
+        <Route element={<RootLayout />}>
+          {/* 홈페이지 & 검색페이지 */}
+          <Route path="/" element={<HomePage />} />
+          <Route path="/search" element={<SearchPage />} />
+          <Route path="/community" element={<CommunityPage />} />
+          <Route path="/mypage" element={<MyPage />} />
+        </Route>
 
-      {/* 제품 관련 페이지들 */}
-      <Route path="/product" element={<RootLayout />}>
-        <Route index element={<ProductsPage />} />
-      </Route>
+        {/* 제품 관련 페이지들 */}
+        <Route path="/product" element={<RootLayout />}>
+          <Route index element={<ProductsPage />} />
+        </Route>
 
-      <Route path="/product/:id" element={<ProductDetailPage />} />
-      <Route path="/product/register" element={<ProductRegistrationPage />} />
-      <Route path="/product/modify" element={<div>등록한 제품 수정</div>} />
-      <Route path="*" element={<NotFoundPage />} />
+        <Route path="/product/:id" element={<ProductDetailPage />} />
+        <Route path="/product/register" element={<ProductRegistrationPage />} />
+        <Route path="/product/modify" element={<div>등록한 제품 수정</div>} />
+        <Route path="*" element={<NotFoundPage />} />
 
-      {/* 구매 관련 페이지들 */}
-      <Route
-        path="/purchase/*"
-        element={
-          <Routes>
-            <Route path="/:id" element={<ProductPurchasePage />} />
-            <Route path="/complete" element={<PaymentCompletePage />} />
-          </Routes>
-        }
-      />
+        {/* 구매 관련 페이지들 */}
+        <Route
+          path="/purchase/*"
+          element={
+            <Routes>
+              <Route path="/:id" element={<ProductPurchasePage />} />
+              <Route path="/complete" element={<PaymentCompletePage />} />
+            </Routes>
+          }
+        />
 
-      {/* 커뮤니티 관련 페이지들 */}
-      <Route
-        path="/community/*"
-        element={
-          <Routes>
-            <Route path="/" element={<div>커뮤니티 메인 페이지</div>} />
-            <Route path="/:id" element={<div>판매자 공지 톡방</div>} />
-          </Routes>
-        }
-      />
+        {/* 커뮤니티 관련 페이지들 */}
+        {/* 마이페이지 전용 레이아웃이었지만 다른 곳에도 사용할 예정 */}
+        <Route path="/*" element={<MyPageLayout />}>
+          <Route path="community/:id" element={<CommunityPostPage />} />
+        </Route>
 
-      {/* 채팅 관련 페이지들 */}
-      <Route element={<RootLayout />}>
-        <Route path="/chatting" element={<ChatListPage />} />
-      </Route>
-      <Route path="/chatting/:id" element={<ChatPage />} />
+        {/* 채팅 관련 페이지들 */}
+        <Route element={<RootLayout />}>
+          <Route path="/chatting" element={<ChatListPage />} />
+        </Route>
+        <Route path="/chatting/:id" element={<ChatPage />} />
 
-      {/* 마이페이지 관련 페이지들 */}
+        {/* 마이페이지 관련 페이지들 */}
 
-      <Route
-        path="/mypage/*"
-        element={
-          <Routes>
-            <Route path="/profile" element={<div>프로필 수정</div>} />
-            <Route path="/my-products" element={<div>내 판매 상품들</div>} />
-          </Routes>
-        }
-      />
+        <Route
+          path="/mypage/*"
+          element={
+            <Routes>
+              <Route path="/my-products" element={<div>내 판매 상품들</div>} />
+            </Routes>
+          }
+        />
 
-      <Route path="/mypage/*" element={<MyPageLayout />}>
-        <Route path="charge" element={<PointPage />} />
-        <Route path="profile" element={<ChangeProfilePage />} />
-        <Route path="verify-seller" element={<VerifySellerPage />} />
-        <Route path="likes" element={<LikeListPage />} />
-        <Route path="deliveries" element={<DeliveriesPage />} />
-        <Route path="password" element={<ChangePasswordPage />} />
+        <Route path="/mypage/*" element={<MyPageLayout />}>
+          <Route path="charge" element={<PointPage />} />
+          <Route path="profile" element={<ChangeProfilePage />} />
+          <Route path="verify-seller" element={<VerifySellerPage />} />
+          <Route path="likes" element={<LikeListPage />} />
+          <Route path="deliveries" element={<DeliveriesPage />} />
+          <Route path="password" element={<ChangePasswordPage />} />
+        </Route>
       </Route>
     </Routes>
   );

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -16,7 +16,7 @@ import ProductPurchasePage from "../pages/product/ProductPurchasePage";
 import PaymentCompletePage from "@/pages/product/PaymentCompletePage";
 import ChatListPage from "@/pages/chat/ChatListPage";
 import ChatPage from "@/pages/chat/ChatPage";
-import MyPageLayout from "@/pages/mypage/components/MyPageLayout";
+import PageLayout from "@/pages/mypage/components/PageLayout";
 import MyPage from "@/pages/mypage/mypage/MyPage";
 import PointPage from "@/pages/mypage/charge/PointPage";
 import VerifySellerPage from "@/pages/mypage/verifySeller/VerifySellerPage";
@@ -28,7 +28,6 @@ import CommunityPage from "@/pages/community/CommunityPage";
 import CommunityPostPage from "@/pages/community/CommunityPostPage";
 import ProtectedRoute from "@/routes/ProtectedRoute";
 
-/* TODO: 라우트별 element를 임시로 채운 부분 해당 컴포넌트로 수정 */
 /* TODO: Route들을 묶어서 파일 관리로 수정 예정 */
 const Router = (): JSX.Element => {
   return (
@@ -55,64 +54,66 @@ const Router = (): JSX.Element => {
       <Route element={<ProtectedRoute />}>
         {/* TODO: 홈/검색 외에도 루트 레이아웃으로 감쌀 예정 */}
         <Route element={<RootLayout />}>
-          {/* 홈페이지 & 검색페이지 */}
+          {/* FNB를 갖는 모바일 메뉴 메인 페이지들 */}
           <Route path="/" element={<HomePage />} />
           <Route path="/search" element={<SearchPage />} />
           <Route path="/community" element={<CommunityPage />} />
-          <Route path="/mypage" element={<MyPage />} />
-        </Route>
-
-        {/* 제품 관련 페이지들 */}
-        <Route path="/product" element={<RootLayout />}>
-          <Route index element={<ProductsPage />} />
-        </Route>
-
-        <Route path="/product/:id" element={<ProductDetailPage />} />
-        <Route path="/product/register" element={<ProductRegistrationPage />} />
-        <Route path="/product/modify" element={<div>등록한 제품 수정</div>} />
-        <Route path="*" element={<NotFoundPage />} />
-
-        {/* 구매 관련 페이지들 */}
-        <Route
-          path="/purchase/*"
-          element={
-            <Routes>
-              <Route path="/:id" element={<ProductPurchasePage />} />
-              <Route path="/complete" element={<PaymentCompletePage />} />
-            </Routes>
-          }
-        />
-
-        {/* 커뮤니티 관련 페이지들 */}
-        {/* 마이페이지 전용 레이아웃이었지만 다른 곳에도 사용할 예정 */}
-        <Route path="/*" element={<MyPageLayout />}>
-          <Route path="community/:id" element={<CommunityPostPage />} />
-        </Route>
-
-        {/* 채팅 관련 페이지들 */}
-        <Route element={<RootLayout />}>
+          <Route path="/product" element={<ProductsPage />} />
           <Route path="/chatting" element={<ChatListPage />} />
-        </Route>
-        <Route path="/chatting/:id" element={<ChatPage />} />
+          <Route path="/mypage" element={<MyPage />} />
 
-        {/* 마이페이지 관련 페이지들 */}
+          {/* 404 Not Found */}
+          <Route path="*" element={<NotFoundPage />} />
 
-        <Route
-          path="/mypage/*"
-          element={
-            <Routes>
-              <Route path="/my-products" element={<div>내 판매 상품들</div>} />
-            </Routes>
-          }
-        />
+          {/* FNB가 없는 기본 페이지 레이아웃 */}
+          <Route path="/*" element={<PageLayout />}>
+            {/* 제품 관련 페이지들 */}
+            <Route
+              path="product/*"
+              element={
+                <Routes>
+                  <Route path="product/:id" element={<ProductDetailPage />} />
+                  <Route path="product/register" element={<ProductRegistrationPage />} />
+                  {/* 제품 등록 페이지 재사용 예정 */}
+                  <Route path="product/modify" element={<div>등록한 제품 수정</div>} />
+                </Routes>
+              }
+            />
 
-        <Route path="/mypage/*" element={<MyPageLayout />}>
-          <Route path="charge" element={<PointPage />} />
-          <Route path="profile" element={<ChangeProfilePage />} />
-          <Route path="verify-seller" element={<VerifySellerPage />} />
-          <Route path="likes" element={<LikeListPage />} />
-          <Route path="deliveries" element={<DeliveriesPage />} />
-          <Route path="password" element={<ChangePasswordPage />} />
+            {/* 커뮤니티 관련 페이지들 */}
+            <Route path="community/:id" element={<CommunityPostPage />} />
+
+            {/* 구매 관련 페이지들 */}
+            <Route
+              path="purchase/*"
+              element={
+                <Routes>
+                  <Route path="/:id" element={<ProductPurchasePage />} />
+                  <Route path="/complete" element={<PaymentCompletePage />} />
+                </Routes>
+              }
+            />
+
+            {/* 채팅 관련 페이지들 */}
+            <Route path="chatting/:id" element={<ChatPage />} />
+
+            {/* 마이페이지 관련 페이지들 */}
+            <Route
+              path="mypage/*"
+              element={
+                <Routes>
+                  <Route path="charge" element={<PointPage />} />
+                  <Route path="profile" element={<ChangeProfilePage />} />
+                  <Route path="verify-seller" element={<VerifySellerPage />} />
+                  <Route path="likes" element={<LikeListPage />} />
+                  <Route path="deliveries" element={<DeliveriesPage />} />
+                  <Route path="password" element={<ChangePasswordPage />} />
+                  {/* API 미구현 페이지 */}
+                  <Route path="my-products" element={<div>내 판매 상품들</div>} />
+                </Routes>
+              }
+            />
+          </Route>
         </Route>
       </Route>
     </Routes>

--- a/src/stores/mypage.ts
+++ b/src/stores/mypage.ts
@@ -1,9 +1,29 @@
 import { atom } from "jotai";
-import { CommonHeaderProps } from "@/components/CommonHeader";
 
-export const myPageHeaderProps = atom<CommonHeaderProps>({
+interface headerBaseProps {
+  title: string;
+  onBack?: () => void;
+  backRoute: string;
+}
+
+interface headerWithConfirm extends headerBaseProps {
+  hasConfirm: true; // hasConfirm이 true일 때
+  confirmText: string; // confirmText는 필수
+  onConfirm?: () => void;
+}
+
+interface headerWithoutConfirm extends headerBaseProps {
+  hasConfirm: false; // hasConfirm이 false일 때
+  confirmText?: null; // confirmText는 선택
+  onConfirm?: null;
+}
+
+export type pageLayoutHeaderProps = headerWithConfirm | headerWithoutConfirm;
+
+export const pageLayoutHeaderProps = atom<pageLayoutHeaderProps>({
   title: "",
   onBack: undefined,
+  backRoute: "/",
   hasConfirm: false,
   confirmText: null,
   onConfirm: null,

--- a/src/utils/storageUtils.ts
+++ b/src/utils/storageUtils.ts
@@ -1,0 +1,32 @@
+interface TokenAndInfoProps {
+  token: {
+    accessToken: string;
+    accessExpiredAt: string;
+  };
+  loginMember: {
+    nickname: string;
+    email: string;
+    provider: "EMAIL" | "KAKAO" | "NAVER";
+  };
+}
+
+export const setTokenAndInfo = ({ token, loginMember }: TokenAndInfoProps) => {
+  const { accessToken, accessExpiredAt } = token;
+  const { nickname, email, provider } = loginMember;
+
+  localStorage.setItem("accessToken", accessToken);
+  localStorage.setItem("accessExpiredAt", accessExpiredAt);
+  localStorage.setItem("nickname", nickname);
+  localStorage.setItem("email", email);
+  localStorage.setItem("provider", provider);
+};
+
+export const getLocalStorageData = (key: string) => {
+  // 추후에 데이터를 객체로 보관하면 사용
+
+  return localStorage.getItem(key);
+};
+
+export const removeLocalStorage = () => {
+  localStorage.clear();
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -405,6 +405,14 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.2.1.tgz#558fb6472ed16a4c850b889530e6b36438c49280"
   integrity sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==
 
+"@jridgewell/source-map@^0.3.3":
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/@jridgewell/source-map/-/source-map-0.3.6.tgz#9d71ca886e32502eb9362c9a74a46787c36df81a"
+  integrity sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.5"
+    "@jridgewell/trace-mapping" "^0.3.25"
+
 "@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz#3188bcb273a414b0d215fd22a58540b989b9409a"
@@ -813,7 +821,7 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn@^8.12.0:
+acorn@^8.12.0, acorn@^8.8.2:
   version "8.12.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.12.1.tgz#71616bdccbe25e27a54439e0046e89ca76df2248"
   integrity sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==
@@ -978,6 +986,11 @@ browserslist@^4.23.1, browserslist@^4.23.3:
     node-releases "^2.0.18"
     update-browserslist-db "^1.1.0"
 
+buffer-from@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
+  integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
@@ -1105,6 +1118,11 @@ combined-stream@^1.0.8:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@^2.20.0:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 commander@^4.0.0:
   version "4.1.1"
@@ -2855,6 +2873,19 @@ source-map-js@^1.2.0:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.0.tgz#16b809c162517b5b8c3e7dcd315a2a5c2612b2af"
   integrity sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==
 
+source-map-support@~0.5.20:
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
 statuses@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
@@ -3009,6 +3040,16 @@ tailwindcss@^3.4.10:
     postcss-selector-parser "^6.0.11"
     resolve "^1.22.2"
     sucrase "^3.32.0"
+
+terser@^5.33.0:
+  version "5.33.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.33.0.tgz#8f9149538c7468ffcb1246cfec603c16720d2db1"
+  integrity sha512-JuPVaB7s1gdFKPKTelwUyRq5Sid2A3Gko2S0PncwdBq7kN9Ti9HPWDQ06MPsEDGsZeVESjKEnyGy68quBk1w6g==
+  dependencies:
+    "@jridgewell/source-map" "^0.3.3"
+    acorn "^8.8.2"
+    commander "^2.20.0"
+    source-map-support "~0.5.20"
 
 text-table@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
## 작업

### 루트 레이아웃과 페이지 레이아웃

- /auth를 제외한 모든 페이지에 루트 레이아웃과 페이지 레이아웃 적용
  - 루트 레이아웃
    - 메인 헤더와 FNB를 갖는 반응형 레이아웃
    - FNB 메뉴의 메인 페이지가 아니라면 렌더링 안되게 수정
  - 페이지 레이아웃
    - FNB 메뉴페이지가 아닌 모든 페이지에 적용하는 반응형 레이아웃
    - 사이즈에 비례하여 좌우 padding이 달라짐
    - 페이지 레이아웃 전용 헤더를 갖고 있으며 useSetAtom으로 페이지마다 업데이트

### 공용 함수

- 뒤로 가기 함수의 기존 로직에서 브라우저 히스토리 스택을 먼저 참고하는 방식으로 변경
- localStorage 관련 함수 추가

### 라이브러리 추가

- 빌드 결과물의 경량화를 위한 terser 추가

## 참고 사항

- 페이지 레이아웃의 공용 헤더에 제목과 뒤로가기 등을 적용하기 위해 useEffect로 jotai setter를 해줘야함
  -> @JIHU96 가 모든 페이지에 적용할 예정
- 페이지 레이아웃 적용으로 인해 각 페이지의 width를 수정해야 할 수도 있음

## 관련 이슈
<!-- - Close #이슈번호 -->
